### PR TITLE
Get us on the global Thali build infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,19 @@ __How__: We are really just a thin Java wrapper around the Tor OP binaries and j
 
 __Who__: This work is part of the [Thali Project](http://www.thaliproject.org/mediawiki/index.php?title=Main_Page) and is being actively developed by Yaron Y. Goland assigned to the Microsoft Open Technologies Hub. We absolutely need your help! Please see the FAQ below if you would like to help!
 
-To use the library clone the repo and run first run './gradlew uploadArchives' (make sure you have local maven installed) on Universal. Then run './gradlew build' on either the Android or Java project depending on your needs. The Android project contains an ARM binary. The Java project contains binaries for Linux, Mac and Windows. Note that the Java project requires an additional JAR file that you can find in Universal/libs. Alternatively if you use Maven and uploadArchives then we will install the JAR file in maven local and you can just refer to it that way. For example, one of our Java projects has the following in its gradle
+To use the library:
+1. Install local Maven
+2. Clone the repo.
+3. In your gradle.properties file (I usually keep mine in the .gradle sub-directory of my home directory, gradle knows to look there) put in the following properties:
+```
+systemProp.MAVEN_UPLOAD_REPO_URL=System.getProperty('user.home') + '.m2/repository'
+systemProp.MAVEN_UPLOAD_VERSION=0.0.0
+```
+These are the values you need to publish to your local maven.
+4. Then run './gradlew uploadArchives' on Universal. 
+5. Then run './gradlew build' on either the Android or Java project depending on your needs. The Android project contains an ARM binary. The Java project contains binaries for Linux, Mac and Windows. 
+
+Note that the Java project requires an additional JAR file that you can find in Universal/libs. Alternatively if you use Maven and uploadArchives then we will install the JAR file in maven local and you can just refer to it that way. For example, one of our Java projects has the following in its gradle
 
 ```groovy
     compile 'com.msopentech.thali:ThaliOnionProxyJava:0.0.0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,25 +49,19 @@ android {
 dependencies {
     compile fileTree(dir: '../universal/libs', include: '*.jar')
     compile 'org.slf4j:slf4j-api:1.7.7'
-    compile 'com.msopentech.thali:ThaliOnionProxyUniversal:0.0.0'
+    compile 'com.msopentech.thali:ThaliOnionProxyUniversal:' + System.getProperty('MAVEN_UPLOAD_VERSION')
 
     androidTestCompile 'org.slf4j:slf4j-android:1.7.7'
-}
-
-def mavenPath() {
-    artifactory_local == "true" ?
-            'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath :
-            artifactory_contextUrl + "/libs-release-local"
 }
 
 uploadArchives {
     repositories {
         mavenDeployer {
-            repository(url: mavenPath()) {
-                authentication(userName: "${artifactory_user}", password: "${artifactory_password}")
+            repository(url: System.getProperty('MAVEN_UPLOAD_REPO_URL')) {
+                authentication(userName: System.getProperty('MAVEN_UPLOAD_USERNAME'), password: System.getProperty('MAVEN_UPLOAD_PASSWORD'))
             }
 
-            pom.version = "0.0.0"
+            pom.version = System.getProperty('MAVEN_UPLOAD_VERSION')
             pom.groupId = 'com.msopentech.thali'
             pom.artifactId = 'ThaliOnionProxyAndroid'
             pom.project {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,0 @@
-artifactory_user=user
-artifactory_password=foo
-artifactory_local=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip

--- a/android/src/androidTest/java/com/msopentech/thali/local/toronionproxy/TorOnionProxyTestCase.java
+++ b/android/src/androidTest/java/com/msopentech/thali/local/toronionproxy/TorOnionProxyTestCase.java
@@ -23,8 +23,4 @@ public class TorOnionProxyTestCase extends AndroidTestCase {
     public OnionProxyManager getOnionProxyManager(String workingSubDirectoryName) {
         return new AndroidOnionProxyManager(getContext(), workingSubDirectoryName);
     }
-
-    public OnionProxyContext getOnionProxyContext(String workingSubDirectoryName) {
-        return new AndroidOnionProxyContext(getContext(), workingSubDirectoryName);
-    }
 }

--- a/android/src/androidTest/java/com/msopentech/thali/toronionproxy/TorOnionProxySmokeTest.java
+++ b/android/src/androidTest/java/com/msopentech/thali/toronionproxy/TorOnionProxySmokeTest.java
@@ -94,12 +94,12 @@ public class TorOnionProxySmokeTest extends TorOnionProxyTestCase {
         String clientManagerDirectoryName = "clientmanager";
         OnionProxyManager hiddenServiceManager = null, clientManager = null;
         try {
-            deleteTorWorkingDirectory(hiddenServiceManagerDirectoryName);
             hiddenServiceManager = getOnionProxyManager(hiddenServiceManagerDirectoryName);
+            deleteTorWorkingDirectory(hiddenServiceManager.getWorkingDirectory());
             assertTrue(hiddenServiceManager.startWithRepeat(30, 5));
 
-            deleteTorWorkingDirectory(clientManagerDirectoryName);
             clientManager = getOnionProxyManager(clientManagerDirectoryName);
+            deleteTorWorkingDirectory(clientManager.getWorkingDirectory());
             assertTrue(clientManager.startWithRepeat(30, 5));
 
             String onionAddress = runHiddenServiceTest(hiddenServiceManager, clientManager);
@@ -215,9 +215,7 @@ public class TorOnionProxySmokeTest extends TorOnionProxyTestCase {
         return countDownLatch;
     }
 
-    private void deleteTorWorkingDirectory(String workingSubDirectoryName) {
-        OnionProxyContext onionProxyContext = getOnionProxyContext(workingSubDirectoryName);
-        File torWorkingDirectory = onionProxyContext.getWorkingDirectory();
+    private void deleteTorWorkingDirectory(File torWorkingDirectory) {
         FileUtilities.recursiveFileDelete(torWorkingDirectory);
         if (torWorkingDirectory.mkdirs() == false) {
             throw new RuntimeException("couldn't create Tor Working Directory after deleting it.");

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -25,23 +25,17 @@ repositories {
 dependencies {
     compile fileTree(dir: '../universal/libs', include: '*.jar')
     compile 'org.slf4j:slf4j-api:1.7.7'
-    compile 'com.msopentech.thali:ThaliOnionProxyUniversal:0.0.0'
+    compile 'com.msopentech.thali:ThaliOnionProxyUniversal:' + System.getProperty('MAVEN_UPLOAD_VERSION')
 
     testCompile 'junit:junit:4.11'
     testCompile 'org.slf4j:slf4j-simple:1.7.7'
 }
 
-def mavenPath() {
-    artifactory_local == "true" ?
-            'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath :
-            artifactory_contextUrl + "/libs-release-local"
-}
-
 uploadArchives {
     repositories {
         mavenDeployer {
-            repository(url: mavenPath()) {
-                authentication(userName: "${artifactory_user}", password: "${artifactory_password}")
+            repository(url: System.getProperty('MAVEN_UPLOAD_REPO_URL')) {
+                authentication(userName: System.getProperty('MAVEN_UPLOAD_USERNAME'), password: System.getProperty('MAVEN_UPLOAD_PASSWORD'))
             }
 
             addFilter('briarjtorctl') {artifact, file ->
@@ -53,13 +47,13 @@ uploadArchives {
             }
 
             pom('thalionionproxy') {
-                version = "0.0.0"
+                version = System.getProperty('MAVEN_UPLOAD_VERSION')
                 groupId = 'com.msopentech.thali'
                 artifactId = 'ThaliOnionProxyJava'
             }
 
             pom('briarjtorctl') {
-                version = "0.0.0"
+                version = System.getProperty('MAVEN_UPLOAD_VERSION')
                 groupId = 'com.msopentech.thali'
                 artifactId = 'BriarJtorctl'
             }

--- a/java/gradle.properties
+++ b/java/gradle.properties
@@ -1,3 +1,0 @@
-artifactory_user=user
-artifactory_password=foo
-artifactory_local=true

--- a/java/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip

--- a/java/src/main/java/com/msopentech/thali/java/toronionproxy/JavaOnionProxyContext.java
+++ b/java/src/main/java/com/msopentech/thali/java/toronionproxy/JavaOnionProxyContext.java
@@ -22,8 +22,8 @@ import java.io.InputStream;
 
 public class JavaOnionProxyContext extends OnionProxyContext {
 
-    public JavaOnionProxyContext(String workingSubDirectoryName) {
-        super(new File("OnionProxyJavaTests", workingSubDirectoryName));
+    public JavaOnionProxyContext(File workingDirectory) {
+        super(workingDirectory);
     }
 
     @Override

--- a/java/src/test/java/com/msopentech/thali/local/toronionproxy/TorOnionProxyTestCase.java
+++ b/java/src/test/java/com/msopentech/thali/local/toronionproxy/TorOnionProxyTestCase.java
@@ -19,13 +19,21 @@ import com.msopentech.thali.toronionproxy.OnionProxyContext;
 import com.msopentech.thali.toronionproxy.OnionProxyManager;
 import junit.framework.TestCase;
 
-public class TorOnionProxyTestCase extends TestCase {
-    public OnionProxyManager getOnionProxyManager(String workingSubDirectoryName) {
-        return new JavaOnionProxyManager(new JavaOnionProxyContext(workingSubDirectoryName));
-    }
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
-    public OnionProxyContext getOnionProxyContext(String workingSubDirectoryName) {
-        return new JavaOnionProxyContext(workingSubDirectoryName);
+public class TorOnionProxyTestCase extends TestCase {
+    protected OnionProxyContext testOnionProxyContext = null;
+
+    public OnionProxyManager getOnionProxyManager(String workingSubDirectoryName) {
+        try {
+            return new JavaOnionProxyManager(
+                    new JavaOnionProxyContext(
+                            Files.createTempDirectory(workingSubDirectoryName).toFile()));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public void testTorOnionProxyTestCaseSetupProperly() {

--- a/universal/build.gradle
+++ b/universal/build.gradle
@@ -30,20 +30,14 @@ dependencies {
     testCompile 'org.slf4j:slf4j-simple:1.7.7'
 }
 
-def mavenPath() {
-    artifactory_local == "true" ?
-            'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath :
-            artifactory_contextUrl + "/libs-release-local"
-}
-
 uploadArchives {
     repositories {
         mavenDeployer {
-            repository(url: mavenPath()) {
-                authentication(userName: "${artifactory_user}", password: "${artifactory_password}")
+            repository(url: System.getProperty('MAVEN_UPLOAD_REPO_URL')) {
+                authentication(userName: System.getProperty('MAVEN_UPLOAD_USERNAME'), password: System.getProperty('MAVEN_UPLOAD_PASSWORD'))
             }
 
-            pom.version = "0.0.0"
+            pom.version = System.getProperty('MAVEN_UPLOAD_VERSION')
             pom.groupId = 'com.msopentech.thali'
             pom.artifactId = 'ThaliOnionProxyUniversal'
             pom.project {

--- a/universal/src/main/java/com/msopentech/thali/toronionproxy/OnionProxyManager.java
+++ b/universal/src/main/java/com/msopentech/thali/toronionproxy/OnionProxyManager.java
@@ -404,6 +404,15 @@ public abstract class OnionProxyManager {
         }
     }
 
+    /**
+     * Returns the root directory in which the Tor Onion Proxy keeps its files. This is mostly intended
+     * for debugging purposes.
+     * @return Working directory for Tor Onion Proxy files
+     */
+    public File getWorkingDirectory() {
+        return onionProxyContext.getWorkingDirectory();
+    }
+
     protected void eatStream(final InputStream inputStream, final boolean stdError, final CountDownLatch countDownLatch) {
         new Thread() {
             @Override


### PR DESCRIPTION
Get project to use same build infrastructure as the rest of Thali, see
the build.gradle files. Also updated the README to include this data.

Upgrade local gradle to 1.12

Change tor context constructor to take file object, this presumes we
will figure the file location outside the constructor. This was useful
for debugging.
