### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/universal/src/main/java/com/msopentech/thali/toronionproxy/FileUtilities.java
+++ b/universal/src/main/java/com/msopentech/thali/toronionproxy/FileUtilities.java
@@ -77,6 +77,8 @@ import java.util.zip.ZipInputStream;
 public class FileUtilities {
     private static final Logger LOG = LoggerFactory.getLogger(FileUtilities.class);
 
+    private FileUtilities() {}
+
     /**
      * Closes both input and output streams when done.
      * @param in Stream to read from

--- a/universal/src/main/java/com/msopentech/thali/toronionproxy/Utilities.java
+++ b/universal/src/main/java/com/msopentech/thali/toronionproxy/Utilities.java
@@ -24,6 +24,8 @@ public class Utilities {
     private static final int READ_TIMEOUT_MILLISECONDS = 60000;
     private static final int CONNECT_TIMEOUT_MILLISECONDS = 60000;
 
+    private Utilities() {}
+
     /**
      * When making a request via the Tor Proxy one needs to establish the socket using SOCKS4a. However Android
      * only supports SOCKS4 so this class provides a wrapper when getting a socket to handle things.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/tor_onion_proxy_library/41)
<!-- Reviewable:end -->
