### PR TITLE
Code quality fix - Literal boolean values should not be used in condition expressions.

### DIFF
--- a/android/src/androidTest/java/com/msopentech/thali/toronionproxy/TorOnionProxySmokeTest.java
+++ b/android/src/androidTest/java/com/msopentech/thali/toronionproxy/TorOnionProxySmokeTest.java
@@ -263,7 +263,7 @@ public class TorOnionProxySmokeTest extends TorOnionProxyTestCase {
 
     private void deleteTorWorkingDirectory(File torWorkingDirectory) {
         FileUtilities.recursiveFileDelete(torWorkingDirectory);
-        if (torWorkingDirectory.mkdirs() == false) {
+        if (!torWorkingDirectory.mkdirs()) {
             throw new RuntimeException("couldn't create Tor Working Directory after deleting it.");
         }
     }

--- a/android/src/main/java/com/msopentech/thali/android/toronionproxy/AndroidWriteObserver.java
+++ b/android/src/main/java/com/msopentech/thali/android/toronionproxy/AndroidWriteObserver.java
@@ -45,7 +45,7 @@ public class AndroidWriteObserver extends FileObserver implements WriteObserver 
     public AndroidWriteObserver(File file) {
         super(file.getAbsolutePath(), CLOSE_WRITE);
 
-        if (file.exists() == false) {
+        if (!file.exists()) {
             throw new IllegalArgumentException("FileObserver doesn't work properly on files that don't already exist.");
         }
 

--- a/java/src/main/java/com/msopentech/thali/java/toronionproxy/JavaWatchObserver.java
+++ b/java/src/main/java/com/msopentech/thali/java/toronionproxy/JavaWatchObserver.java
@@ -53,7 +53,7 @@ public class JavaWatchObserver implements WriteObserver {
 
 
     public JavaWatchObserver(File fileToWatch) throws IOException {
-        if (fileToWatch == null || fileToWatch.exists() == false) {
+        if (fileToWatch == null || !fileToWatch.exists()) {
             throw new RuntimeException("fileToWatch must not be null and must already exist.");
         }
         this.fileToWatch = fileToWatch;
@@ -107,7 +107,7 @@ public class JavaWatchObserver implements WriteObserver {
 
                     // In case we haven't yet gotten the event we are looking for we have to reset in order to
                     // receive any further notifications.
-                    if (key.reset() == false) {
+                    if (!key.reset()) {
                         LOG.error("The key became invalid which should not have happened.");
                     }
                 }

--- a/universal/src/main/java/com/msopentech/thali/toronionproxy/FileUtilities.java
+++ b/universal/src/main/java/com/msopentech/thali/toronionproxy/FileUtilities.java
@@ -143,7 +143,7 @@ public class FileUtilities {
      * @throws java.io.IOException - If any of the file operations fail
      */
     public static void cleanInstallOneFile(InputStream readFrom, File fileToWriteTo) throws IOException {
-        if (fileToWriteTo.exists() && fileToWriteTo.delete() == false) {
+        if (fileToWriteTo.exists() && !fileToWriteTo.delete()) {
             throw new RuntimeException("Could not remove existing file " + fileToWriteTo.getName());
         }
         OutputStream out = new FileOutputStream(fileToWriteTo);
@@ -157,7 +157,7 @@ public class FileUtilities {
             }
         }
 
-        if (fileOrDirectory.exists() && fileOrDirectory.delete() == false) {
+        if (fileOrDirectory.exists() && fileOrDirectory.delete()) {
             throw new RuntimeException("Could not delete directory " + fileOrDirectory.getAbsolutePath());
         }
     }
@@ -177,17 +177,17 @@ public class FileUtilities {
             while ((zipEntry = zipInputStream.getNextEntry()) != null) {
                 File file = new File(destinationDirectory, zipEntry.getName());
                 if (zipEntry.isDirectory()) {
-                    if (file.exists() == false && file.mkdirs() == false) {
+                    if (file.exists() == false && !file.mkdirs()) {
                         throw new RuntimeException("Could not create directory " + file);
                     }
                 } else {
-                    if (file.exists() && file.delete() == false) {
+                    if (file.exists() && !file.delete()) {
                         throw new RuntimeException(
                                 "Could not delete file in preparation for overwriting it. File - " +
                                         file.getAbsolutePath());
                     }
 
-                    if (file.createNewFile() == false) {
+                    if (!file.createNewFile()) {
                         throw new RuntimeException("Could not create file " + file);
                     }
 

--- a/universal/src/main/java/com/msopentech/thali/toronionproxy/OnionProxyContext.java
+++ b/universal/src/main/java/com/msopentech/thali/toronionproxy/OnionProxyContext.java
@@ -53,7 +53,7 @@ abstract public class OnionProxyContext {
         // do by default, something we hope to fix with https://github.com/thaliproject/Tor_Onion_Proxy_Library/issues/13
         Thread.sleep(1000,0);
 
-        if (workingDirectory.exists() == false && workingDirectory.mkdirs() == false) {
+        if (!workingDirectory.exists() && !workingDirectory.mkdirs()) {
             throw new RuntimeException("Could not create root directory!");
         }
 
@@ -152,7 +152,7 @@ abstract public class OnionProxyContext {
                     FileUtilities.recursiveFileDelete(file);
                 }
             } else {
-                if (file.delete() == false) {
+                if (!file.delete()) {
                     throw new RuntimeException("Could not delete file " + file.getAbsolutePath());
                 }
             }

--- a/universal/src/main/java/com/msopentech/thali/toronionproxy/OnionProxyManager.java
+++ b/universal/src/main/java/com/msopentech/thali/toronionproxy/OnionProxyManager.java
@@ -97,14 +97,14 @@ public abstract class OnionProxyManager {
 
         try {
             for(int retryCount = 0; retryCount < numberOfRetries; ++retryCount) {
-                if (installAndStartTorOp() == false) {
+                if (!installAndStartTorOp()) {
                     return false;
                 }
                 enableNetwork(true);
 
                 // We will check every second to see if boot strapping has finally finished
                 for(int secondsWaited = 0; secondsWaited < secondsBeforeTimeOut; ++secondsWaited) {
-                    if (isBootstrapped() == false) {
+                    if (!isBootstrapped()) {
                         Thread.sleep(1000,0);
                     } else {
                         return true;
@@ -125,7 +125,7 @@ public abstract class OnionProxyManager {
             return false;
         } finally {
             // Make sure we return the Tor OP in some kind of consistent state, even if it's 'off'.
-            if (isRunning() == false) {
+            if (!isRunning()) {
                 stop();
             }
         }
@@ -137,7 +137,7 @@ public abstract class OnionProxyManager {
      * @throws java.io.IOException - File errors
      */
     public synchronized int getIPv4LocalHostSocksPort() throws IOException {
-        if (isRunning() == false) {
+        if (!isRunning()) {
             throw new RuntimeException("Tor is not running!");
         }
 
@@ -168,21 +168,21 @@ public abstract class OnionProxyManager {
 
         List<ConfigEntry> currentHiddenServices = controlConnection.getConf("HiddenServiceOptions");
 
-        if ((currentHiddenServices.size() == 1 &&
+        if (!(currentHiddenServices.size() == 1 &&
                 currentHiddenServices.get(0).key.compareTo("HiddenServiceOptions") == 0 &&
-                currentHiddenServices.get(0).value.compareTo("") == 0) == false) {
+                currentHiddenServices.get(0).value.compareTo("") == 0)) {
             throw new RuntimeException("Sorry, only one hidden service to a customer and we already have one. Please send complaints to https://github.com/thaliproject/Tor_Onion_Proxy_Library/issues/5 with your scenario so we can justify fixing this.");
         }
 
         LOG.info("Creating hidden service");
         File hostnameFile = onionProxyContext.getHostNameFile();
 
-        if (hostnameFile.getParentFile().exists() == false &&
-                hostnameFile.getParentFile().mkdirs() == false) {
+        if (!hostnameFile.getParentFile().exists() &&
+                !hostnameFile.getParentFile().mkdirs()) {
             throw new RuntimeException("Could not create hostnameFile parent directory");
         }
 
-        if (hostnameFile.exists() == false && hostnameFile.createNewFile() == false) {
+        if (!hostnameFile.exists() && !hostnameFile.createNewFile()) {
             throw new RuntimeException("Could not create hostnameFile");
         }
 
@@ -324,15 +324,15 @@ public abstract class OnionProxyManager {
 
         LOG.info("Starting Tor");
         File cookieFile = onionProxyContext.getCookieFile();
-        if (cookieFile.getParentFile().exists() == false &&
-                cookieFile.getParentFile().mkdirs() == false) {
+        if (!cookieFile.getParentFile().exists() &&
+                !cookieFile.getParentFile().mkdirs()) {
             throw new RuntimeException("Could not create cookieFile parent directory");
         }
 
         // The original code from Briar watches individual files, not a directory and Android's file observer
         // won't work on files that don't exist. Rather than take 5 seconds to rewrite Briar's code I instead
         // just make sure the file exists
-        if (cookieFile.exists() == false && cookieFile.createNewFile() == false) {
+        if (!cookieFile.exists() && !cookieFile.createNewFile()) {
             throw new RuntimeException("Could not create cookieFile");
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1125 - Literal boolean values should not be used in condition expressions. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1125

Please let me know if you have any questions.

Faisal Hameed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/tor_onion_proxy_library/43)
<!-- Reviewable:end -->
