### PR TITLE
Add OsType.UNSUPPORTED

### DIFF
--- a/universal/src/main/java/com/msopentech/thali/toronionproxy/OsData.java
+++ b/universal/src/main/java/com/msopentech/thali/toronionproxy/OsData.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.util.Scanner;
 
 public class OsData {
-    public enum OsType {WINDOWS, LINUX_32, LINUX_64, MAC, ANDROID}
+    public enum OsType {WINDOWS, LINUX_32, LINUX_64, MAC, ANDROID, UNSUPPORTED}
     private static OsType detectedType = null;
 
     public static OsType getOsType() {
@@ -62,7 +62,7 @@ public class OsData {
         } else if (osName.contains("Linux")) {
             return getLinuxType();
         }
-        throw new RuntimeException("Unsupported OS");
+        return OsType.UNSUPPORTED;
     }
 
     protected static OsType getLinuxType() {
@@ -90,7 +90,7 @@ public class OsData {
             if (unameOutput.compareTo("x86_64") == 0) {
                 return OsType.LINUX_64;
             }
-            throw new RuntimeException("Could not understand uname output, not sure what bitness");
+            return OsType.UNSUPPORTED;
         } catch (IOException e) {
             throw new RuntimeException("Uname failure", e);
         } catch (InterruptedException e) {


### PR DESCRIPTION
We would love to see OsType.UNSUPPORTED added.
This would allow caching the result in `detectedType` variable instead of throwing `RuntimeException`, and differentiating this case from system errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/tor_onion_proxy_library/126)
<!-- Reviewable:end -->
