### PR TITLE
Change tor.so to libtor.so in TorConfig and AndroidTorConfig

### DIFF
--- a/android/src/main/java/com/msopentech/thali/android/toronionproxy/AndroidTorConfig.java
+++ b/android/src/main/java/com/msopentech/thali/android/toronionproxy/AndroidTorConfig.java
@@ -34,7 +34,7 @@ public class AndroidTorConfig {
      */
     public static TorConfig createConfig(File alternativeInstallDir, File configDir, Context context) {
         File nativeDir = new File(context.getApplicationInfo().nativeLibraryDir);
-        File torExecutable = new File(nativeDir,  "tor.so");
+        File torExecutable = new File(nativeDir,  "libtor.so");
 
         if(torExecutable.exists()) {
             Log.d(TAG, "Tor executable exists in native library directory: " + nativeDir.getAbsolutePath());

--- a/universal/src/main/java/com/msopentech/thali/toronionproxy/TorConfig.java
+++ b/universal/src/main/java/com/msopentech/thali/toronionproxy/TorConfig.java
@@ -445,7 +445,7 @@ public final class TorConfig {
         private static String getTorExecutableFileName() {
             switch (OsData.getOsType()) {
                 case ANDROID:
-                    return "tor.so";
+                    return "libtor.so";
                 case LINUX_32:
                 case LINUX_64:
                 case MAC:


### PR DESCRIPTION
When working with newer versions of `tor-android` (i.e `org.torproject:tor-android-binary:0.4.2.7a`), the so-file is named `libtor.so`.  
This is because in Android SDK 29, the file won't be copied to the `nativeLibraryDir` unless it's prefixed with lib.

This is commit changes `AndroidTorConfig` and `TorConfig` to use `libtor.so` instead, to be able to work with newer versions of `tor-android`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/tor_onion_proxy_library/152)
<!-- Reviewable:end -->
