### PR TITLE
Fix jtorctl dependency not being downloadable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ subprojects {
   repositories {
     mavenLocal()
     mavenCentral()
-    maven { url "https://repo.spring.io/plugins-release" }
+    jcenter()
   }
 }
 


### PR DESCRIPTION
This PR replaces repo.spring.io/plugins-release with jcenter.
It seems like jtorctl is no longer available on repo.spring.io/plugins-release, thus the lib will fail to compile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/tor_onion_proxy_library/155)
<!-- Reviewable:end -->
